### PR TITLE
Clean up documentation typos and formatting

### DIFF
--- a/Assembly.md
+++ b/Assembly.md
@@ -44,27 +44,27 @@ With all 3 modules attached to the bottom base plate:
 
         <img src="media/assembly_imgs/IMG_1925.jpg" width="400" /> <img src="media/assembly_imgs/IMG_1928.jpg" width="400" />
 
-    - For the **5V version**: you can use the powerbamk holder to keep the powerbank in place `3DPrintMeshes/5v_specific/5v_power_bank_holder.stl`. The powerbank can be mounted in the back on the lower plate.
+    - For the **5V version**: you can use the power bank holder to keep the power bank in place: `3DPrintMeshes/5v_specific/5v_power_bank_holder.stl`. The power bank can be mounted at the back of the lower plate.
 
         <img src="media/assembly_imgs/IMG_7.jpg" width="400" />
         
-      The cables can be connected  according to following diagram:
+      The cables can be connected according to the following diagram:
       
         <img src="media/assembly_imgs/Slide1.jpeg" width="400" />
 
 ### 3. Top plate Assembly
-1. Place the raspberry pi 5 into the pi case bottom and snap on the top part of the case. 
+1. Place the Raspberry Pi 5 into the Pi case bottom and snap on the top part of the case.
 2. Attach the Pi to the top base plate using 2 m3x12 machine screws and mount the SO-101 arm with 4 m3x20 machine screws. Using our modified SO-101 base or the original will work as there are holes for both in the plate.
 
     <img src="media/assembly_imgs/IMG_1929.jpg" width="400" />
 
-- For the **Wired version**: you can print these two parts: `3DPrintMeshes/wired_specific/cable_holder v0.stl` and `3DPrintMeshes/wired_specific/usb_connector_case v1.stl` and assemble them like the images below. It is **very important** to plug the usb-c cable in the way like the images. Thus the `UGreen` logo on the same side as `20GBS, 240W` logo side. And the `20GBS, 240W` side on top into your laptop. If the usb-c extenstion cable can't find your camera's or motor controller board, the cable orientation is probably wrong and should be flipped 180 degrees!
+- For the **Wired version**: you can print these two parts, `3DPrintMeshes/wired_specific/cable_holder v0.stl` and `3DPrintMeshes/wired_specific/usb_connector_case v1.stl`, and assemble them as shown in the images below. It is **very important** to plug in the USB-C cable in the orientation shown. The `UGreen` logo should be on the same side as the `20GBS, 240W` label, with the `20GBS, 240W` side facing up when connected to your laptop. If the USB-C extension cable cannot detect your cameras or motor controller board, the cable orientation is probably wrong and should be flipped 180 degrees.
 
     Add cable holder and usb hub holder like this:
 
     <img src="media/assembly_imgs/WIRED4.jpeg" width="400" />
 
-    Attach cables for 2 camera's motor control board and usb-c extender like this (important!):
+    Attach the cables for the two cameras, motor control board, and USB-C extender as shown (important!):
 
     <div style="display: flex; align-items: flex-start;">
      <img src="media/assembly_imgs/WIRED1.jpeg" width="30%" alt="Wired Step 1" />
@@ -74,7 +74,7 @@ With all 3 modules attached to the bottom base plate:
 
 
 ### 4. Final Assembly
-1. Feed the servo controller usb-c to usb-a, 5v usb-c power, and SO0-101 servo wires through the hole in the top base plate. 
+1. Feed the servo controller USB-C to USB-A cable, 5V USB-C power cable, and SO-101 servo wires through the hole in the top base plate.
 
     <img src="media/assembly_imgs/IMG_1930.jpg" width="300" />
 
@@ -85,16 +85,16 @@ With all 3 modules attached to the bottom base plate:
 ### 5: Attach Cameras
 *Note: The mounts we designed are specific to the cameras we chose. They may need to be modified for different camera modules.*
 #### (Option 1) Mounting Arducam
-For these [camera's](https://www.amazon.com/Arducam-Camera-Computer-Without-Microphone/dp/B0972KK7BC) you can print these parts 1x `3DPrintMeshes/base_camera_mount.stl` and 1x `3DPrintMeshes/wrist_camera_mount.stl`.
-1. Screw the base camera mount onto the bottom base plate(attach the arducam 5MP wide angle camera to the mount with 2 m2.5x12 machine screws). The cable for the camera mount can also be fed through the cutout
+For these [cameras](https://www.amazon.com/Arducam-Camera-Computer-Without-Microphone/dp/B0972KK7BC), you can print these parts: 1x `3DPrintMeshes/base_camera_mount.stl` and 1x `3DPrintMeshes/wrist_camera_mount.stl`.
+1. Screw the base camera mount onto the bottom base plate (attach the Arducam 5MP wide-angle camera to the mount with 2 M2.5x12 machine screws). The cable for the camera mount can also be fed through the cutout.
 
     <img src="media/assembly_imgs/IMG_1935.jpg" width="300" />
-2. Screw the wrist camera mount to the static gripper using 4 m2x5 tap screws(attach the arducam 5MP wide angle camera to the mount with 2 m2.5x12 machine screws)
+2. Screw the wrist camera mount to the static gripper using 4 M2x5 tapping screws (attach the Arducam 5MP wide-angle camera to the mount with 2 M2.5x12 machine screws).
 
     <img src="media/assembly_imgs/IMG_1934.jpg" width="300" />
 
 #### (Option 2) Mounting Webcam
-For these [camera's](https://www.amazon.fr/Vinmooog-equipement-Microphone-Enregistrement-conférences/dp/B0BG1YJWFN/) you can print these parts 1x `3DPrintMeshes/webcam_mount/webcam_mount.stl`, 1x `3DPrintMeshes/webcam_mount/so100_gripper_cam_mount_insert.stl` and 1x `3DPrintMeshes/webcam_mount/webcam_mount_wrist.stl`. These can be used to attach a wrist and base camera to LeKiwi.
+For these [cameras](https://www.amazon.fr/Vinmooog-equipement-Microphone-Enregistrement-conférences/dp/B0BG1YJWFN/), you can print these parts: 1x `3DPrintMeshes/webcam_mount/webcam_mount.stl`, 1x `3DPrintMeshes/webcam_mount/so100_gripper_cam_mount_insert.stl`, and 1x `3DPrintMeshes/webcam_mount/webcam_mount_wrist.stl`. These can be used to attach a wrist and base camera to LeKiwi.
 
 1. Print the new gripper with insert for the M3 nut, and insert the nut. Then insert the motor and attach gripper. 
 
@@ -108,7 +108,7 @@ For these [camera's](https://www.amazon.fr/Vinmooog-equipement-Microphone-Enregi
     <img src="media/assembly_imgs/IMG_2.jpg" width="300" />
 
 
-### Plug everything in and its ready!
-Power the electronics by plugging in the DC barrel plug adapter to the servo motor controller and the 5v usb-c connector to the raspberry pi 5. The usb cables from the servo controller and the cameras can directly be plugged in to the raspberry pi.
+### Plug everything in and it's ready!
+Power the electronics by plugging the DC barrel plug adapter into the servo motor controller and the 5V USB-C connector into the Raspberry Pi 5. The USB cables from the servo controller and the cameras can be plugged directly into the Raspberry Pi.
 
 <img src="media/assembly_imgs/IMG_1940.jpg" width="400" /> <img src="media/assembly_imgs/IMG_1938.jpg" width="400" />

--- a/DynamixelLeKiwi/3DPrinting.md
+++ b/DynamixelLeKiwi/3DPrinting.md
@@ -10,10 +10,10 @@ We provide ready-to-print STL files for the 3D-printed parts below. These can be
 |:---|:---:|:---:|
 | [Center triangular insert](/3DPrintMeshes/dynamixel_specific/center_triangular_insert.stl) | 2 |  |
 | [Dynamixel Drive motor mount](/3DPrintMeshes/dynamixel_specific/dynamixel_kiwi_servo_mount.stl) | 3 | |
-| [Dynamixel Servo wheel hub](/3DPrintMeshes/dynamixel_specific/Dynamixel_omni_wheel_mount%20v2.stl) | 3 | Use Supports<sup>[1](#footnote1)</sup> | |
+| [Dynamixel Servo wheel hub](/3DPrintMeshes/dynamixel_specific/Dynamixel_omni_wheel_mount%20v2.stl) | 3 | Use Supports<sup>[1](#footnote1)</sup> |
 | [Lipo battery mount](/3DPrintMeshes/dynamixel_specific/lipo_battery_mount.stl) | 1 | |
 | [RasPi case Top](/3DPrintMeshes/pi_case_top.stl) | 1 | <sup>[2](#footnote2)</sup> |
-| [RasPi case Bottom](/3DPrintMeshes/dynamixel_specific/pi_case_bottom.stl) | 1 | <sup>[2](#footnote2)</sup> ||
+| [RasPi case Bottom](/3DPrintMeshes/dynamixel_specific/pi_case_bottom.stl) | 1 | <sup>[2](#footnote2)</sup> |
 | Webcam [base mount](/3DPrintMeshes/dynamixel_specific/webcam_base_mount.stl), [static gripper w/ mount](/3DPrintMeshes/dynamixel_specific/modified_static_side_with_mount.stl) | 1 | **Compatible with [this camera](https://www.amazon.fr/Vinmooog-equipement-Microphone-Enregistrement-conférences/dp/B0BG1YJWFN/)** |
 | [Modified Follower Arm Base](/3DPrintMeshes/dynamixel_specific/follower_base.stl) | 1 |  |
 | [Follower arm](https://github.com/jess-moss/koch-v1-1) | 1 |Use with the modified base and static gripper  |

--- a/DynamixelLeKiwi/BOM.md
+++ b/DynamixelLeKiwi/BOM.md
@@ -4,7 +4,7 @@ This page provides a complete list of parts needed to build the Dynamixel LeKiwi
 
 | Price| US  | EU  | CN |
 |---------|----:|----:|----:|
-| **Dynamixel LeKiwi** |  **$770.47**  |  **€1021.60**  |  **¥6074**  ||
+| **Dynamixel LeKiwi** |  **$770.47**  |  **€1021.60**  |  **¥6074**  |
 | **Base only** |  **$339.47**  |  **€378.60**  |  **¥2127.28**  |
 
 
@@ -19,9 +19,9 @@ This page provides a complete list of parts needed to build the Dynamixel LeKiwi
 | Part | Amount | Unit Cost (US) | Buy (US) | Unit Cost (EU) | Buy (EU) | Unit Cost (CN) | Buy (CN) |
 | - | - | - | - | - | - | - | - |
 | 4" Omni wheels | 3 | $9.99 | [VEX Robotics](https://www.vexrobotics.com/omni-wheels.html?srsltid=AfmBOorWdWT-FIiWSAbicYWSxqYr-d5X3CJSGxMkO33WO0thwlTn4DQu) | €24.5 | [RobotShop](https://eu.robotshop.com/products/100mm-omnidirectional-wheel-brass-bearing-rollers) |￥135 |[PDD](https://mobile.yangkeduo.com/goods.html?ps=kKWPC7xuzw "https://mobile.yangkeduo.com/goods.html?ps=kKWPC7xuzw")|
-| M2 M3 M4 Assorted Screw Set | 1 | $14.99 | [Amazon](https://www.amazon.com/Button-Socket-Washers-Assortment-Machine/dp/B0BMQGJP3F) | €23.5 | [Amazon](https://www.amazon.fr/Cylindrique-Inoxydable-M2-Socket-Assortiment/dp/B09Y8WYFWD/) |￥25 |[Taobao（M2x5+M3套装+M3x10+M4x12）](https://e.tb.cn/h.64O1J2A9Is4pIJd "https://e.tb.cn/h.64O1J2A9Is4pIJd")   
+| M2 M3 M4 Assorted Screw Set | 1 | $14.99 | [Amazon](https://www.amazon.com/Button-Socket-Washers-Assortment-Machine/dp/B0BMQGJP3F) | €23.5 | [Amazon](https://www.amazon.fr/Cylindrique-Inoxydable-M2-Socket-Assortiment/dp/B09Y8WYFWD/) |￥25 |[Taobao（M2x5+M3套装+M3x10+M4x12）](https://e.tb.cn/h.64O1J2A9Is4pIJd "https://e.tb.cn/h.64O1J2A9Is4pIJd") |
 | TB3 Waffle Plate Set | 1 | $19.00 | [ROBOTIS](https://en.robotis.com/shop_en/item.php?it_id=903-0259-000) | €16.3 | [ROBOTIS](https://en.robotis.com/shop_en/item.php?it_id=903-0259-000) |￥136 |[Robotis US (ships to China)](https://en.robotis.com/shop_en/item.php?it_id=903-0259-000)           |
-| **Total** || **$63.96** || **€€113.30** || **¥566** ||
+| **Total** || **$63.96** || **€113.30** || **¥566** ||
 
 ### Sensors and Compute:
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - (5V version) 65W Laptop power bank
 
 > [!TIP]  
-> If this is the first time you build robots please choose the 5V version as it’s a little bit easier to assemble. If you are more experienced and want to lift heavier objects choose the 12V version. If you want to cheapest option possible go for the wired LeKiwi version.
+> If this is the first time you build robots please choose the 5V version as it’s a little bit easier to assemble. If you are more experienced and want to lift heavier objects choose the 12V version. If you want the cheapest option possible go for the wired LeKiwi version.
 
 #### Compute
 - Raspberry Pi 5
@@ -57,6 +57,7 @@ We also provide the [URDF](./URDF/) exported from CAD for simulation.
 <div style="display: flex; justify-content: center; align-items: center; padding: 25px;">
     <img src="./media/assembly_imgs/IMG_9252.jpg" width="300" /> 
     <img src="./media/assembly_imgs/IMG_9256.jpg" width="300" /> 
+</div>
 
 We converted LeKiwi to use ROBOTIS components by using the Koch v1.1 arm, U2D2 motor controller, and Dynamixel XL430 motors for the mobile base.  [Dynamixel LeKiwi](DynamixelLeKiwi)
 


### PR DESCRIPTION
## What changed

- Corrected typos and grammar in the README and assembly instructions.
- Closed the Dynamixel image container in the README.
- Fixed malformed rows in the Dynamixel BOM and 3D-printing tables.

## Why

These errors made parts of the assembly guide harder to follow and caused several Markdown tables to render with extra or missing columns.

## Checks

- Confirmed all local Markdown links resolve.
- Confirmed edited tables have consistent column counts.
- Ran `git diff --check`.
