### PR TITLE
Add citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+cff-version: 1.2.0
+message: "If you use LeKiwi in your research, please cite it using the metadata from this file."
+title: LeKiwi
+abstract: "A low-cost mobile manipulator built around the LeRobot ecosystem."
+type: software
+authors:
+  - given-names: Pepijn
+    family-names: Kooijmans
+  - given-names: Manav
+    family-names: Chandaka
+  - given-names: Bhargav
+    family-names: Chandaka
+  - given-names: Gloria
+    family-names: Wang
+  - given-names: Advait
+    family-names: Patel
+repository-code: "https://github.com/SIGRobotics-UIUC/LeKiwi"
+url: "https://huggingface.co/docs/lerobot/lekiwi"
+license: Apache-2.0
+keywords:
+  - robotics
+  - mobile manipulator
+  - LeRobot

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ We converted LeKiwi to use ROBOTIS components by using the Koch v1.1 arm, U2D2 m
 
 Join the project on LeRobot's [Discord server](https://discord.gg/Jtz5TJtb2u) (channel `mobile-so100-arm`)! Let us know if you have any questions, suggestions, or other feedback.
 
+## Citation
+
+If you use LeKiwi in your research, please cite the repository using the metadata in [CITATION.cff](CITATION.cff). GitHub's **Cite this repository** menu provides APA and BibTeX citations.
+
 ## Main Contributors
 Thank you to everyone who helped on the project!
 


### PR DESCRIPTION
## What changed

- Added a `CITATION.cff` file with the project authors, repository URL, license, and research keywords.
- Added a README citation section explaining how to copy APA or BibTeX citations from GitHub.

## Why

Researchers currently have no canonical citation guidance for LeKiwi. This gives them a repository citation immediately without implying that a paper or DOI already exists.

Refs #27.

## Checks

- Validated `CITATION.cff` against the Citation File Format 1.2.0 schema with `cffconvert --validate`.
- Confirmed the new README link resolves locally.
- Ran `git diff --check`.

