### PR TITLE
Add standard ROS base frames to URDF

### DIFF
--- a/URDF/LeKiwi.urdf
+++ b/URDF/LeKiwi.urdf
@@ -1,5 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <robot name="LeKiwi">
+    <link name="base_footprint" />
+    <link name="base_link" />
     <link name="base_plate_layer1-v5">
         <inertial>
             <origin xyz="-4.730687660675253e-15 -2.7155537377808555e-05 -0.0035000000000000005" rpy="0.0 0.0 0.0" />
@@ -855,6 +857,16 @@
             </geometry>
         </collision>
     </link>
+    <joint name="base_footprint_to_base_link" type="fixed">
+        <origin xyz="0.0 0.0 0.032937" rpy="0.0 0.0 0.0" />
+        <parent link="base_footprint" />
+        <child link="base_link" />
+    </joint>
+    <joint name="base_link_to_base_plate" type="fixed">
+        <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 -1.5707963267948966" />
+        <parent link="base_link" />
+        <child link="base_plate_layer1-v5" />
+    </joint>
     <joint name="base_plate_layer1-v5_baseplate2bottom_mount" type="fixed">
         <origin xyz="-0.02 -0.1 0.0" rpy="3.141592653589793 -0.0 0.0" />
         <parent link="base_plate_layer1-v5" />

--- a/URDF/README.md
+++ b/URDF/README.md
@@ -1,0 +1,9 @@
+# LeKiwi URDF
+
+The URDF uses the standard ROS mobile-base coordinate convention:
+
+- `base_footprint` is the root frame at ground level, with +X forward, +Y left, and +Z up.
+- `base_link` has the same orientation and is located at the original CAD origin, 32.937 mm above the ground plane.
+- `base_plate_layer1-v5` and its descendants retain their generated CAD frames and names to preserve the existing kinematic tree.
+
+Mesh paths are relative to `LeKiwi.urdf`, so load the model with the `URDF` directory as its base path.


### PR DESCRIPTION
## What changed

- Added `base_footprint` as a ground-level root frame.
- Added `base_link` with the standard ROS orientation: +X forward, +Y left, and +Z up.
- Lifted the preserved CAD tree by 32.937 mm so the wheel geometry rests on the ground plane.
- Documented the new frames and the relationship to the generated CAD links.

## Why

The generated URDF previously used the bottom base plate as its root, placed wheel geometry below the ground plane, and used +Y as the robot's forward direction. This made the model awkward to integrate with ROS navigation and visualization tools.

This addresses the base-frame, ground-transform, and forward-axis portions of #14. It deliberately leaves the generated link names, joint names, and internal kinematic tree unchanged for a later contribution.

## Checks

- Parsed the model with `urdf_parser_py`.
- Verified a single 47-link tree rooted at `base_footprint`.
- Calculated transformed mesh bounds and confirmed the lowest wheel point is at 0 m.
- Confirmed the CAD +Y axis maps to ROS +X.
- Confirmed all 45 existing links and 44 existing joints remain unchanged.
- Ran `git diff --check`.
