### PR TITLE
Use LeRobot names for actuated URDF joints

### DIFF
--- a/URDF/JOINT_NAMES.md
+++ b/URDF/JOINT_NAMES.md
@@ -1,0 +1,21 @@
+# URDF joint names
+
+The nine actuated joints use the same names as the LeKiwi motors in
+[LeRobot](https://github.com/huggingface/lerobot/blob/main/src/lerobot/robots/lekiwi/lekiwi.py).
+This makes joint-state and command dictionaries directly comparable between the
+robot driver and the URDF.
+
+| LeRobot/URDF name | Previous generated URDF name |
+| --- | --- |
+| `base_left_wheel` | `ST3215_Servo_Motor-v1_Revolute-64` |
+| `base_back_wheel` | `ST3215_Servo_Motor-v1-2_Revolute-60` |
+| `base_right_wheel` | `ST3215_Servo_Motor-v1-1_Revolute-62` |
+| `arm_shoulder_pan` | `STS3215_03a-v1_Revolute-45` |
+| `arm_shoulder_lift` | `STS3215_03a-v1-1_Revolute-49` |
+| `arm_elbow_flex` | `STS3215_03a-v1-2_Revolute-51` |
+| `arm_wrist_flex` | `STS3215_03a-v1-3_Revolute-53` |
+| `arm_wrist_roll` | `STS3215_03a_Wrist_Roll-v1_Revolute-55` |
+| `arm_gripper` | `STS3215_03a-v1-4_Revolute-57` |
+
+Consumers that refer to joints by name must update from the generated names in
+the right column to the stable names in the left column.

--- a/URDF/LeKiwi.urdf
+++ b/URDF/LeKiwi.urdf
@@ -870,7 +870,7 @@
         <parent link="omni_wheel_mount-v5-2" />
         <child link="4-Omni-Directional-Wheel_Single_Body-v1-2" />
     </joint>
-    <joint name="ST3215_Servo_Motor-v1-2_Revolute-60" type="continuous">
+    <joint name="base_back_wheel" type="continuous">
         <origin xyz="0.010249999999999999 -0.035199999999999995 -0.03275" rpy="-1.5707963267948966 1.5707963267948966 0" />
         <parent link="ST3215_Servo_Motor-v1-2" />
         <child link="omni_wheel_mount-v5-2" />
@@ -886,7 +886,7 @@
         <parent link="drive_motor_mount-v11-1" />
         <child link="ST3215_Servo_Motor-v1-1" />
     </joint>
-    <joint name="ST3215_Servo_Motor-v1-1_Revolute-62" type="continuous">
+    <joint name="base_right_wheel" type="continuous">
         <origin xyz="0.010249999999999999 0.04636234 -0.014801910000000005" rpy="-1.5707963267948966 1.5707963267948966 0" />
         <parent link="ST3215_Servo_Motor-v1-1" />
         <child link="omni_wheel_mount-v5-1" />
@@ -907,7 +907,7 @@
         <parent link="drive_motor_mount-v11" />
         <child link="ST3215_Servo_Motor-v1" />
     </joint>
-    <joint name="ST3215_Servo_Motor-v1_Revolute-64" type="continuous">
+    <joint name="base_left_wheel" type="continuous">
         <origin xyz="0.010249999999999999 -0.010762340000000004 0.046859090000000006" rpy="-1.5707963267948966 1.5707963267948966 0" />
         <parent link="ST3215_Servo_Motor-v1" />
         <child link="omni_wheel_mount-v5" />
@@ -993,7 +993,7 @@
         <parent link="Base_08q-v1" />
         <child link="STS3215_03a-v1" />
     </joint>
-    <joint name="STS3215_03a-v1_Revolute-45" type="continuous">
+    <joint name="arm_shoulder_pan" type="continuous">
         <origin xyz="-0.010250000000000084 0.03459999999999999 -0.032799999999999996" rpy="1.5707963267948966 -2.781046729970605e-32 3.94430452610506e-31" />
         <parent link="STS3215_03a-v1" />
         <child link="Rotation_Pitch_08i-v1" />
@@ -1014,7 +1014,7 @@
         <parent link="Rotation_Pitch_08i-v1" />
         <child link="STS3215_03a-v1-1" />
     </joint>
-    <joint name="STS3215_03a-v1-1_Revolute-49" type="continuous">
+    <joint name="arm_shoulder_lift" type="continuous">
         <origin xyz="0.0346 0.010249999999999987 -0.032799999999999975" rpy="3.141592653589793 1.7181275903033976e-32 -3.1373434374976504e-48" />
         <parent link="STS3215_03a-v1-1" />
         <child link="SO_ARM100_08k_116_Square-v1" />
@@ -1025,7 +1025,7 @@
         <parent link="SO_ARM100_08k_116_Square-v1" />
         <child link="STS3215_03a-v1-2" />
     </joint>
-    <joint name="STS3215_03a-v1-2_Revolute-51" type="continuous">
+    <joint name="arm_elbow_flex" type="continuous">
         <origin xyz="0.0346 -0.013069710000000002 0.03178184000000002" rpy="-6.842277657836021e-49 -3.4512664603419266e-31 -1.3877787807814457e-17" />
         <parent link="STS3215_03a-v1-2" />
         <child link="SO_ARM100_08k_Mirror-v1" />
@@ -1036,7 +1036,7 @@
         <parent link="SO_ARM100_08k_Mirror-v1" />
         <child link="STS3215_03a-v1-3" />
     </joint>
-    <joint name="STS3215_03a-v1-3_Revolute-53" type="continuous">
+    <joint name="arm_wrist_flex" type="continuous">
         <origin xyz="0.0346 -0.03408158 0.004398620000000015" rpy="3.1415926535897922 9.860761315262648e-32 -9.503163413661107e-47" />
         <parent link="STS3215_03a-v1-3" />
         <child link="Wrist_Roll_Pitch_08i-v1" />
@@ -1047,7 +1047,7 @@
         <parent link="Wrist_Roll_Pitch_08i-v1" />
         <child link="STS3215_03a_Wrist_Roll-v1" />
     </joint>
-    <joint name="STS3215_03a_Wrist_Roll-v1_Revolute-55" type="continuous">
+    <joint name="arm_wrist_roll" type="continuous">
         <origin xyz="-0.028999999999999998 0.00810632 0.006869499999999995" rpy="3.141592653589793 -0.0 0.0" />
         <parent link="STS3215_03a_Wrist_Roll-v1" />
         <child link="Wrist_Roll_08c-v1" />
@@ -1058,7 +1058,7 @@
         <parent link="Wrist_Roll_08c-v1" />
         <child link="STS3215_03a-v1-4" />
     </joint>
-    <joint name="STS3215_03a-v1-4_Revolute-57" type="continuous">
+    <joint name="arm_gripper" type="continuous">
         <origin xyz="-0.032799999999999996 -0.023912249999999986 0.027026410000000018" rpy="-1.5707963267948968 3.944304526105059e-31 -1.9721522630525295e-31" />
         <parent link="STS3215_03a-v1-4" />
         <child link="Moving_Jaw_08d-v1" />


### PR DESCRIPTION
## Summary

- rename all nine actuated URDF joints to match the current LeRobot LeKiwi motor API
- document the old-to-new joint name mapping for downstream users
- leave link names, fixed joints, transforms, axes, and geometry unchanged

## Why

The generated Fusion joint names are hard to use in joint-state and command interfaces. Matching LeRobot's names gives the URDF a stable vocabulary that corresponds directly to the robot driver.

This addresses the joint-name portion of #14. It does not rename links or update the motor-mount geometry.

## Validation

- parsed the URDF with `urdf_parser_py`
- confirmed the model remains a 45-link, 44-joint tree with nine continuous joints
- normalized the nine changed name attributes and confirmed the before/after XML is otherwise identical
- ran `git diff --check`
